### PR TITLE
Add localized tool slugs

### DIFF
--- a/app/(public)/[locale]/tools/[slug]/page.tsx
+++ b/app/(public)/[locale]/tools/[slug]/page.tsx
@@ -32,7 +32,10 @@ const converters = getConverters(); // one CSV/JSON read at build time
 
 export async function generateStaticParams() {
   return LOCALES.flatMap((locale) =>
-    converters.map((c) => ({ locale, slug: c.slug_en }))
+    converters.map((c) => ({
+      locale,
+      slug: locale === 'ar' ? c.slug_ar : c.slug_en,
+    }))
   );
 }
 
@@ -57,7 +60,9 @@ export async function generateMetadata({
     ? `أداة سحابية مجانية وسهلة ${row.label_ar} – حوّل ملفات ${fromExt} إلى ${toExt} في ثوانٍ مع الحفاظ على التنسيق والصور والخطوط.`
     : `Free online tool for ${row.label_en}. Convert ${fromExt} to ${toExt} in seconds and keep fonts, images and formatting intact.`;
 
-  const canonical = `${siteUrl}/${locale}/tools/${row.slug_en}`;
+  const canonical = `${siteUrl}/${locale}/tools/${
+    isAr ? row.slug_ar : row.slug_en
+  }`;
 
   const keywords = isAr
     ? [
@@ -113,7 +118,7 @@ export default async function Page({ params }: { params: PageParams }) {
   if (!row) return notFound();
 
   // Show related for both languages — not only Arabic
-  const related: ConverterRow[] = getRelatedConverters(params.slug);
+  const related: ConverterRow[] = getRelatedConverters(row.slug_en);
 
   // SoftwareApplication schema (per tool)
   const softwareJsonLd = {
@@ -123,7 +128,9 @@ export default async function Page({ params }: { params: PageParams }) {
     alternateName: row.label_ar,
     applicationCategory: 'FileConversionTool',
     operatingSystem: 'All',
-    url: `${siteUrl}/${params.locale}/tools/${row.slug_en}`,
+    url: `${siteUrl}/${params.locale}/tools/${
+      params.locale === 'ar' ? row.slug_ar : row.slug_en
+    }`,
     offers: {
       '@type': 'Offer',
       price: '0',
@@ -153,7 +160,9 @@ export default async function Page({ params }: { params: PageParams }) {
         '@type': 'ListItem',
         position: 3,
         name: params.locale === 'ar' ? row.label_ar : row.label_en,
-        item: `${siteUrl}/${params.locale}/tools/${row.slug_en}`,
+        item: `${siteUrl}/${params.locale}/tools/${
+          params.locale === 'ar' ? row.slug_ar : row.slug_en
+        }`,
       },
     ],
   };

--- a/components/Breadcrumbs.tsx
+++ b/components/Breadcrumbs.tsx
@@ -26,7 +26,9 @@ export default async function Breadcrumbs({
     },
     {
       name: locale === 'ar' ? row.label_ar : row.label_en,
-      url: `${siteUrl}/${locale}/tools/${row.slug_en}`,
+      url: `${siteUrl}/${locale}/tools/${
+        locale === 'ar' ? row.slug_ar : row.slug_en
+      }`,
     },
   ];
 

--- a/components/landing/LandingTemplate.tsx
+++ b/components/landing/LandingTemplate.tsx
@@ -84,7 +84,7 @@ export default function LandingTemplate({
           <ul className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
             {related.map((c) => (
               <li key={c.slug_en}>
-                <Link href={`/ar/tools/${c.slug_en}`}>{c.label_ar}</Link>
+                <Link href={`/ar/tools/${c.slug_ar}`}>{c.label_ar}</Link>
               </li>
             ))}
           </ul>

--- a/lib/server/converters.ts
+++ b/lib/server/converters.ts
@@ -57,22 +57,28 @@ export const getConverters = (): Converter[] =>
   }));
 
 /** Find a single converter by its English slug (used in dynamic routes). */
-export const getConverter = (slug_en: string): Converter | undefined =>
-  getConverters().find((c) => c.slug_en === slug_en);
+/**
+ * Find a single converter by slug.
+ *
+ * Accepts either the English slug (e.g. "word-to-powerpoint") or
+ * the Arabic slug (e.g. "تحويل-وورد-بوربوينت").
+ */
+export const getConverter = (slug: string): Converter | undefined =>
+  getConverters().find((c) => c.slug_en === slug || c.slug_ar === slug);
 
 /**
  * Find up to `limit` converters related to the given slug.
  * A converter is considered related if it shares either the "from" or "to" file extension.
  */
-export function getRelatedConverters(slug_en: string, limit = 4): Converter[] {
+export function getRelatedConverters(slug: string, limit = 4): Converter[] {
   const all = getConverters();
-  const current = all.find((c) => c.slug_en === slug_en);
+  const current = all.find((c) => c.slug_en === slug || c.slug_ar === slug);
   if (!current) return [];
 
   const [fromExt, toExt] = current.dir.split('→');
   const others = all.filter(
     (c) =>
-      c.slug_en !== slug_en &&
+      c.slug_en !== current.slug_en &&
       (c.dir.includes(fromExt) || c.dir.includes(toExt))
   );
 


### PR DESCRIPTION
## Summary
- support Arabic slugs in tool routes
- update breadcrumbs and related links to use locale aware slugs
- allow converter helpers to lookup by Arabic slug

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b66294420832e9edc2c86b610e5fb